### PR TITLE
set -o option assumes bash shell

### DIFF
--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Fail on a single failed command
 set -eo pipefail


### PR DESCRIPTION
The current script defaults to using bourne shell, yet `-o pipefail` is used, which is only available in bash. Changing the shebang line to match accordingly