### PR TITLE
Default JDK/JVM  options

### DIFF
--- a/fish-pepper/run-java-sh/fp-files/java-default-options
+++ b/fish-pepper/run-java-sh/fp-files/java-default-options
@@ -84,4 +84,4 @@ heap_ratio() {
 }
 
 # Echo options, trimming trailing and multiple spaces
-echo "$(max_memory) $(diagnostics) $(cpu_core_tunning) $(gc_tunning)"
+echo "$(max_memory) $(diagnostics) $(cpu_core_tunning) $(gc_tunning)" | awk '$1=$1'

--- a/fish-pepper/run-java-sh/fp-files/java-default-options
+++ b/fish-pepper/run-java-sh/fp-files/java-default-options
@@ -74,7 +74,7 @@ cpu_core_tunning() {
 # -XX:GCTimeRatio=4
 # -XX:AdaptiveSizePolicyWeight=90
 gc_tunning() {
-    echo "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:+ExitOnOutOfMemoryError $(heap_ratio)"
+    echo "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError $(heap_ratio)"
 }
 
 #-XX:MinHeapFreeRatio=20  These parameters tell the heap to shrink aggressively and to grow conservatively.

--- a/fish-pepper/run-java-sh/fp-files/java-default-options
+++ b/fish-pepper/run-java-sh/fp-files/java-default-options
@@ -70,5 +70,18 @@ cpu_core_tunning() {
   fi
 }
 
+# These parameters are necessary when running parallel GC if you want to use the Min and Max Heap Free ratios.
+# -XX:GCTimeRatio=4
+# -XX:AdaptiveSizePolicyWeight=90
+gc_tunning() {
+    echo "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:+ExitOnOutOfMemoryError $(heap_ratio)"
+}
+
+#-XX:MinHeapFreeRatio=20  These parameters tell the heap to shrink aggressively and to grow conservatively.
+#-XX:MaxHeapFreeRatio=40  Thereby optimizing the amount of memory available to the operating system.
+heap_ratio() {
+  echo "-XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40"
+}
+
 # Echo options, trimming trailing and multiple spaces
-echo "$(max_memory) $(diagnostics) $(cpu_core_tunning)" | awk '$1=$1'
+echo "$(max_memory) $(diagnostics) $(cpu_core_tunning) $(gc_tunning)"

--- a/fish-pepper/run-java-sh/fp-files/java-default-options
+++ b/fish-pepper/run-java-sh/fp-files/java-default-options
@@ -73,7 +73,7 @@ cpu_core_tunning() {
 # These parameters are necessary when running parallel GC if you want to use the Min and Max Heap Free ratios.
 # -XX:GCTimeRatio=4
 # -XX:AdaptiveSizePolicyWeight=90
-gc_tunning() {
+gc_options() {
     echo "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError $(heap_ratio)"
 }
 
@@ -84,4 +84,4 @@ heap_ratio() {
 }
 
 # Echo options, trimming trailing and multiple spaces
-echo "$(max_memory) $(diagnostics) $(cpu_core_tunning) $(gc_tunning)" | awk '$1=$1'
+echo "$(max_memory) $(diagnostics) $(cpu_core_tunning) $(gc_options)" | awk '$1=$1'


### PR DESCRIPTION
Fix for https://github.com/fabric8io-images/README/issues/3
- added JDK option to tune the GC performance for better memory management
