### PR TITLE
Container limits not working correctly 

### DIFF
--- a/fish-pepper/run-java-sh/fp-files/container-limits
+++ b/fish-pepper/run-java-sh/fp-files/container-limits
@@ -43,8 +43,10 @@ max_memory() {
   if [ -r "${mem_file}" ]; then
     local max_mem_cgroup="$(cat ${mem_file})"
     local max_mem_meminfo=$(($(awk '/MemTotal/ {print $2}' /proc/meminfo)*1024))
-    local max_mem=$(($max_mem_meminfo>$max_mem_cgroup?$max_mem_cgroup:$max_mem_meminfo))
-    echo "${max_mem}"
+    if [ "${max_mem_cgroup}" -ne "-1" ] && [ "${max_mem_cgroup}" -lt "${max_mem_meminfo}" ]
+    then
+      echo "${max_mem_cgroup}"
+    fi
   fi
 }
 

--- a/fish-pepper/run-java-sh/fp-files/container-limits
+++ b/fish-pepper/run-java-sh/fp-files/container-limits
@@ -42,7 +42,7 @@ max_memory() {
   local mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
   if [ -r "${mem_file}" ]; then
     local max_mem_cgroup="$(cat ${mem_file})"
-    local max_mem_meminfo=$(($(awk '/MemTotal/ {print $2}' /proc/meminfo)*1024))
+    local max_mem_cgroup=$(cat /proc/meminfo | awk '/MemTotal/ {printf "%d\n", $2 * 1024}')
     if [ "${max_mem_cgroup}" -ne "-1" ] && [ "${max_mem_cgroup}" -lt "${max_mem_meminfo}" ]
     then
       echo "${max_mem_cgroup}"

--- a/fish-pepper/run-java-sh/fp-files/container-limits
+++ b/fish-pepper/run-java-sh/fp-files/container-limits
@@ -39,13 +39,12 @@ core_limit() {
 max_memory() {
   # High number which is the max limit unti which memory is supposed to be
   # unbounded. 
-  local max_mem_unbounded="$(cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes)"
   local mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
   if [ -r "${mem_file}" ]; then
-    local max_mem="$(cat ${mem_file})"
-    if [ ${max_mem} -lt ${max_mem_unbounded} ]; then
-      echo "${max_mem}"
-    fi
+    local max_mem_cgroup="$(cat ${mem_file})"
+    local max_mem_meminfo=$(($(awk '/MemTotal/ {print $2}' /proc/meminfo)*1024))
+    local max_mem=$(($max_mem_meminfo>$max_mem_cgroup?$max_mem_cgroup:$max_mem_meminfo))
+    echo "${max_mem}"
   fi
 }
 


### PR DESCRIPTION
#32 
Calculate both max mem from /proc/meminfo and from cgroup, use lower number as max memory.