### PR TITLE
fix: Remove awkd printf %d with straight calculations

### DIFF
--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -156,7 +156,7 @@ max_memory() {
   local mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
   if [ -r "${mem_file}" ]; then
     local max_mem_cgroup="$(cat ${mem_file})"
-    local max_mem_meminfo_kb="$(cat /proc/meminfo | awk '/MemTotal/ {print $2}')
+    local max_mem_meminfo_kb="$(cat /proc/meminfo | awk '/MemTotal/ {print $2}')"
     local max_mem_meminfo="$(expr $max_mem_meminfo_kb \* 1024)"
     if [ ${max_mem_cgroup:-0} != -1 ] && [ ${max_mem_cgroup:-0} -lt ${max_mem_meminfo:-0} ]
     then

--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -129,7 +129,7 @@ calc() {
     function round(x) {
       return int(x + 0.5)
     }
-    {printf "%d\n",'"${formula}"'}
+    {print '"${formula}"'}
   '
 }
 
@@ -156,7 +156,8 @@ max_memory() {
   local mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
   if [ -r "${mem_file}" ]; then
     local max_mem_cgroup="$(cat ${mem_file})"
-    local max_mem_meminfo="$(cat /proc/meminfo | awk '/MemTotal/ {printf "%d\n", $2 * 1024}')"
+    local max_mem_meminfo_kb="$(cat /proc/meminfo | awk '/MemTotal/ {print $2}')
+    local max_mem_meminfo="$(expr $max_mem_meminfo_kb \* 1024)"
     if [ ${max_mem_cgroup:-0} != -1 ] && [ ${max_mem_cgroup:-0} -lt ${max_mem_meminfo:-0} ]
     then
       echo "${max_mem_cgroup}"

--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -118,18 +118,18 @@ calc() {
   shift
   echo "$@" | awk '
     function ceil(x) {
-      return x % 1 ? int(x) + 1 : int(x)
+      return x % 1 ? x + 1 : x
     }
     function log2(x) {
-      return int(log(x)/log(2))
+      return log(x)/log(2)
     }
     function max2(x, y) {
-      return x > y ? int(x) : int(y)
+      return x > y ? x : y
     }
     function round(x) {
-      return int(x + 0.5)
+      return x + 0.5
     }
-    {print '"${formula}"'}
+    {print '"int(${formula})"'}
   '
 }
 

--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -118,7 +118,7 @@ calc() {
   shift
   echo "$@" | awk '
     function ceil(x) {
-      return x % 1 ? x + 1 : x
+      return x % 1 ? int(x) + 1 : x
     }
     function log2(x) {
       return log(x)/log(2)
@@ -127,7 +127,7 @@ calc() {
       return x > y ? x : y
     }
     function round(x) {
-      return x + 0.5
+      return int(x + 0.5)
     }
     {print '"int(${formula})"'}
   '

--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -118,13 +118,13 @@ calc() {
   shift
   echo "$@" | awk '
     function ceil(x) {
-      return x % 1 ? int(x) + 1 : x
+      return x % 1 ? int(x) + 1 : int(x)
     }
     function log2(x) {
-      return log(x)/log(2)
+      return int(log(x)/log(2))
     }
     function max2(x, y) {
-      return x > y ? x : y
+      return x > y ? int(x) : int(y)
     }
     function round(x) {
       return int(x + 0.5)


### PR DESCRIPTION
As on alpine there seems to be an overflow on 32bit.
See https://github.com/fabric8io-images/java/issues/16 for more details