### PR TITLE
OSFUSE-728: Restore individual scripts for calculating container limits

### DIFF
--- a/fish-pepper/run-java-sh/copy.dck
+++ b/fish-pepper/run-java-sh/copy.dck
@@ -2,5 +2,5 @@
   var destPath = fp.blockOpts.dest || "";
   destPath = destPath.replace(/\/+$/,"");
 }}# Add run script as {{= destPath }}/run-java.sh and make it executable
-COPY run-java.sh {{= destPath }}/
-RUN chmod 755 {{= destPath }}/run-java.sh
+COPY run-java.sh container-limits java-default-options {{= destPath }}/
+RUN chmod 755 {{= destPath }}/run-java.sh {{= destPath }}/container-limits {{= destPath }}/java-default-options

--- a/fish-pepper/run-java-sh/fp-files/container-limits
+++ b/fish-pepper/run-java-sh/fp-files/container-limits
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# Detected container limits
+# If found these are exposed as the following environment variables:
+#
+# - CONTAINER_MAX_MEMORY
+# - CONTAINER_CORE_LIMIT
+#
+# This script is meant to be sourced.
+
+ceiling() {
+  awk -vnumber="$1" -vdiv="$2" '
+    function ceiling(x){
+      return x % 1 ? int(x) + 1 : x
+    }
+    BEGIN{
+      print ceiling(number/div)
+    }
+  '
+}
+
+# Based on the cgroup limits, figure out the max number of core we should utilize
+core_limit() {
+  local cpu_period_file="/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+  local cpu_quota_file="/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+  if [ -r "${cpu_period_file}" ]; then
+    local cpu_period="$(cat ${cpu_period_file})"
+
+    if [ -r "${cpu_quota_file}" ]; then
+      local cpu_quota="$(cat ${cpu_quota_file})"
+      # cfs_quota_us == -1 --> no restrictions
+      if [ ${cpu_quota:-0} -ne -1 ]; then
+        ceiling "$cpu_quota" "$cpu_period"
+      fi
+    fi
+  fi
+}
+
+max_memory() {
+  # High number which is the max limit until which memory is supposed to be
+  # unbounded.
+  local mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+  if [ -r "${mem_file}" ]; then
+    local max_mem_cgroup="$(cat ${mem_file})"
+    local max_mem_meminfo_kb="$(cat /proc/meminfo | awk '/MemTotal/ {print $2}')"
+    local max_mem_meminfo="$(expr $max_mem_meminfo_kb \* 1024)"
+    if [ ${max_mem_cgroup:-0} != -1 ] && [ ${max_mem_cgroup:-0} -lt ${max_mem_meminfo:-0} ]
+    then
+      echo "${max_mem_cgroup}"
+    fi
+  fi
+}
+
+core_limit="$(core_limit)"
+if [ -n "${core_limit}" ]; then
+  export CONTAINER_CORE_LIMIT="${core_limit}"
+fi
+unset core_limit
+
+mem_limit="$(max_memory)"
+if [ -n "${mem_limit}" ]; then
+  export CONTAINER_MAX_MEMORY="${mem_limit}"
+fi
+unset mem_limit

--- a/fish-pepper/run-java-sh/fp-files/java-default-options
+++ b/fish-pepper/run-java-sh/fp-files/java-default-options
@@ -1,0 +1,187 @@
+#!/bin/sh
+# =================================================================
+# Detect whether running in a container and set appropriate options
+# for limiting Java VM resources
+#
+# Usage: JAVA_OPTIONS="$(java-default-options)"
+
+# Env Vars evaluated:
+
+# JAVA_OPTIONS: Checked for already set options
+# JAVA_MAX_MEM_RATIO: Ratio use to calculate a default maximum Memory, in percent.
+#                     E.g. the "50" value implies that 50% of the Memory
+#                     given to the container is used as the maximum heap memory with
+#                     '-Xmx'.
+#                     It defaults to "25" when the maximum amount of memory available
+#                     to the container is below 300M, otherwise defaults to "50".
+#                     It is a heuristic and should be better backed up with real
+#                     experiments and measurements.
+#                     For a good overviews what tuning options are available -->
+#                             https://youtu.be/Vt4G-pHXfs4
+#                             https://www.youtube.com/watch?v=w1rZOY5gbvk
+#                             https://vimeo.com/album/4133413/video/181900266
+# Also note that heap is only a small portion of the memory used by a JVM. There are lot
+# of other memory areas (metadata, thread, code cache, ...) which addes to the overall
+# size. When your container gets killed because of an OOM, then you should tune
+# the absolute values.
+
+# Generic formula evaluation based on awk
+
+# Generic formula evaluation based on awk
+calc() {
+  local formula="$1"
+  shift
+  echo "$@" | awk '
+    function ceil(x) {
+      return x % 1 ? int(x) + 1 : x
+    }
+    function log2(x) {
+      return log(x)/log(2)
+    }
+    function max2(x, y) {
+      return x > y ? x : y
+    }
+    function round(x) {
+      return int(x + 0.5)
+    }
+    {print '"int(${formula})"'}
+  '
+}
+
+memory_options() {
+  echo "$(calc_init_memory) $(calc_max_memory)"
+  return
+}
+
+# Check for memory options and set max heap size if needed
+calc_max_memory() {
+  # Check whether -Xmx is already given in JAVA_OPTIONS
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xmx"; then
+    return
+  fi
+
+  if [ -z "${CONTAINER_MAX_MEMORY:-}" ]; then
+    return
+  fi
+
+  # Check for the 'real memory size' and calculate Xmx from the ratio
+  if [ -n "${JAVA_MAX_MEM_RATIO:-}" ]; then
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_MAX_MEM_RATIO}" "mx"
+  else
+    if [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
+      # Restore the one-fourth default heap size instead of the one-half below 300MB threshold
+      # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html#default_heap_size
+      calc_mem_opt "${CONTAINER_MAX_MEMORY}" "25" "mx"
+    else
+      calc_mem_opt "${CONTAINER_MAX_MEMORY}" "50" "mx"
+    fi
+  fi
+}
+
+# Check for memory options and set initial heap size if requested
+calc_init_memory() {
+  # Check whether -Xms is already given in JAVA_OPTIONS.
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xms"; then
+    return
+  fi
+
+  # Check if value set
+  if [ -z "${JAVA_INIT_MEM_RATIO:-}" ] || [ -z "${CONTAINER_MAX_MEMORY:-}" ]; then
+    return
+  fi
+
+  # Calculate Xms from the ratio given
+  calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_INIT_MEM_RATIO}" "ms"
+}
+
+calc_mem_opt() {
+  local max_mem="$1"
+  local fraction="$2"
+  local mem_opt="$3"
+
+  local val=$(calc 'round($1*$2/100/1048576)' "${max_mem}" "${fraction}")
+  echo "-X${mem_opt}${val}m"
+}
+
+c2_disabled() {
+  if [ -n "${CONTAINER_MAX_MEMORY:-}" ]; then
+    # Disable C2 compiler when container memory <=300MB
+    if [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
+      echo true
+      return
+    fi
+  fi
+  echo false
+}
+
+jit_options() {
+  # Check whether -XX:TieredStopAtLevel is already given in JAVA_OPTIONS
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-XX:TieredStopAtLevel"; then
+    return
+  fi
+  if [ $(c2_disabled) = true ]; then
+    echo "-XX:TieredStopAtLevel=1"
+  fi
+}
+
+# Switch on diagnostics except when switched off
+diagnostic_options() {
+  if [ -n "${JAVA_DIAGNOSTICS:-}" ]; then
+    echo "-XX:NativeMemoryTracking=summary -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UnlockDiagnosticVMOptions"
+  fi
+}
+
+# Replicate thread ergonomics for tiered compilation.
+# This could ideally be skipped when tiered compilation is disabled.
+# The algorithm is taken from:
+# OpenJDK / jdk8u / jdk8u / hotspot
+# src/share/vm/runtime/advancedThresholdPolicy.cpp
+ci_compiler_count() {
+  local core_limit="$1"
+  local log_cpu=$(calc 'log2($1)' "$core_limit")
+  local loglog_cpu=$(calc 'log2(max2($1,1))' "$log_cpu")
+  local count=$(calc 'max2($1*$2,1)*3/2' "$log_cpu" "$loglog_cpu")
+  local c1_count=$(calc 'max2($1/3,1)' "$count")
+  local c2_count=$(calc 'max2($1-$2,1)' "$count" "$c1_count")
+  [ $(c2_disabled) = true ] && echo "$c1_count" || echo $(calc '$1+$2' "$c1_count" "$c2_count")
+}
+
+cpu_options() {
+  local core_limit="${JAVA_CORE_LIMIT:-}"
+  if [ "$core_limit" = "0" ]; then
+    return
+  fi
+
+  if [ -n "${CONTAINER_CORE_LIMIT:-}" ]; then
+    if [ -z ${core_limit} ]; then
+      core_limit="${CONTAINER_CORE_LIMIT}"
+    fi
+    echo "-XX:ParallelGCThreads=${core_limit} " \
+         "-XX:ConcGCThreads=${core_limit} " \
+         "-Djava.util.concurrent.ForkJoinPool.common.parallelism=${core_limit} " \
+         "-XX:CICompilerCount=$(ci_compiler_count $core_limit)"
+  fi
+}
+
+#-XX:MinHeapFreeRatio=20  These parameters tell the heap to shrink aggressively and to grow conservatively.
+#-XX:MaxHeapFreeRatio=40  Thereby optimizing the amount of memory available to the operating system.
+heap_ratio() {
+  echo "-XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40"
+}
+
+# These parameters are necessary when running parallel GC if you want to use the Min and Max Heap Free ratios.
+# Skip setting gc_options if any other GC is set in JAVA_OPTIONS.
+# -XX:GCTimeRatio=4
+# -XX:AdaptiveSizePolicyWeight=90
+gc_options() {
+    if echo "${JAVA_OPTIONS:-}" | grep -q -- "-XX:.*Use.*GC"; then
+      return
+    fi
+    local opts="-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 $(heap_ratio)"
+    if [ -z "${JAVA_MAJOR_VERSION:-}" ] || [ "${JAVA_MAJOR_VERSION:-}" != "7" ]; then
+      opts="${opts} -XX:+ExitOnOutOfMemoryError"
+    fi
+    echo $opts
+}
+
+echo "$(memory_options) $(jit_options) $(diagnostic_options) $(cpu_options) $(gc_options)" | awk '$1=$1'

--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -112,59 +112,6 @@ find_jar_file() {
   fi
 }
 
-# Generic formula evaluation based on awk
-calc() {
-  local formula="$1"
-  shift
-  echo "$@" | awk '
-    function ceil(x) {
-      return x % 1 ? int(x) + 1 : x
-    }
-    function log2(x) {
-      return log(x)/log(2)
-    }
-    function max2(x, y) {
-      return x > y ? x : y
-    }
-    function round(x) {
-      return int(x + 0.5)
-    }
-    {print '"int(${formula})"'}
-  '
-}
-
-# Based on the cgroup limits, figure out the max number of core we should utilize
-core_limit() {
-  local cpu_period_file="/sys/fs/cgroup/cpu/cpu.cfs_period_us"
-  local cpu_quota_file="/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
-  if [ -r "${cpu_period_file}" ]; then
-    local cpu_period="$(cat ${cpu_period_file})"
-
-    if [ -r "${cpu_quota_file}" ]; then
-      local cpu_quota="$(cat ${cpu_quota_file})"
-      # cfs_quota_us == -1 --> no restrictions
-      if [ ${cpu_quota:-0} -ne -1 ]; then
-        echo $(calc 'ceil($1/$2)' "${cpu_quota}" "${cpu_period}")
-      fi
-    fi
-  fi
-}
-
-max_memory() {
-  # High number which is the max limit until which memory is supposed to be
-  # unbounded.
-  local mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
-  if [ -r "${mem_file}" ]; then
-    local max_mem_cgroup="$(cat ${mem_file})"
-    local max_mem_meminfo_kb="$(cat /proc/meminfo | awk '/MemTotal/ {print $2}')"
-    local max_mem_meminfo="$(expr $max_mem_meminfo_kb \* 1024)"
-    if [ ${max_mem_cgroup:-0} != -1 ] && [ ${max_mem_cgroup:-0} -lt ${max_mem_meminfo:-0} ]
-    then
-      echo "${max_mem_cgroup}"
-    fi
-  fi
-}
-
 load_env() {
   local script_dir="$1"
 
@@ -184,15 +131,12 @@ load_env() {
   fi
   export JAVA_APP_DIR
 
-  # Read in container limits and export the as environment variables
-  local core_limit="$(core_limit)"
-  if [ -n "${core_limit}" ]; then
-    export CONTAINER_CORE_LIMIT="${core_limit}"
-  fi
+  # Memory and CPU limits are calculated in this script
+  local container_limits="container-limits"
 
-  local mem_limit="$(max_memory)"
-  if [ -n "${mem_limit}" ]; then
-    export CONTAINER_MAX_MEMORY="${mem_limit}"
+  # Read in container limits and export them as environment variables
+  if [ -f "${script_dir}/${container_limits}" ]; then
+    . "${script_dir}/${container_limits}"
   fi
 
   # JAVA_LIB_DIR defaults to JAVA_APP_DIR
@@ -269,149 +213,6 @@ format_classpath() {
   fi
 }
 
-# ==========================================================================
-
-memory_options() {
-  echo "$(calc_init_memory) $(calc_max_memory)"
-  return
-}
-
-# Check for memory options and set max heap size if needed
-calc_max_memory() {
-  # Check whether -Xmx is already given in JAVA_OPTIONS
-  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xmx"; then
-    return
-  fi
-
-  if [ -z "${CONTAINER_MAX_MEMORY:-}" ]; then
-    return
-  fi
-
-  # Check for the 'real memory size' and calculate Xmx from the ratio
-  if [ -n "${JAVA_MAX_MEM_RATIO:-}" ]; then
-    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_MAX_MEM_RATIO}" "mx"
-  else
-    if [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
-      # Restore the one-fourth default heap size instead of the one-half below 300MB threshold
-      # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html#default_heap_size
-      calc_mem_opt "${CONTAINER_MAX_MEMORY}" "25" "mx"
-    else
-      calc_mem_opt "${CONTAINER_MAX_MEMORY}" "50" "mx"
-    fi
-  fi
-}
-
-# Check for memory options and set initial heap size if requested
-calc_init_memory() {
-  # Check whether -Xms is already given in JAVA_OPTIONS.
-  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xms"; then
-    return
-  fi
-
-  # Check if value set
-  if [ -z "${JAVA_INIT_MEM_RATIO:-}" ] || [ -z "${CONTAINER_MAX_MEMORY:-}" ]; then
-    return
-  fi
-
-  # Calculate Xms from the ratio given
-  calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_INIT_MEM_RATIO}" "ms"
-}
-
-calc_mem_opt() {
-  local max_mem="$1"
-  local fraction="$2"
-  local mem_opt="$3"
-
-  local val=$(calc 'round($1*$2/100/1048576)' "${max_mem}" "${fraction}")
-  echo "-X${mem_opt}${val}m"
-}
-
-c2_disabled() {
-  if [ -n "${CONTAINER_MAX_MEMORY:-}" ]; then
-    # Disable C2 compiler when container memory <=300MB
-    if [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
-      echo true
-      return
-    fi
-  fi
-  echo false
-}
-
-jit_options() {
-  # Check whether -XX:TieredStopAtLevel is already given in JAVA_OPTIONS
-  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-XX:TieredStopAtLevel"; then
-    return
-  fi
-  if [ $(c2_disabled) = true ]; then
-    echo "-XX:TieredStopAtLevel=1"
-  fi
-}
-
-# Switch on diagnostics except when switched off
-diagnostic_options() {
-  if [ -n "${JAVA_DIAGNOSTICS:-}" ]; then
-    echo "-XX:NativeMemoryTracking=summary -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCTimeStamps -XX:+UnlockDiagnosticVMOptions"
-  fi
-}
-
-# Replicate thread ergonomics for tiered compilation.
-# This could ideally be skipped when tiered compilation is disabled.
-# The algorithm is taken from:
-# OpenJDK / jdk8u / jdk8u / hotspot
-# src/share/vm/runtime/advancedThresholdPolicy.cpp
-ci_compiler_count() {
-  local core_limit="$1"
-  local log_cpu=$(calc 'log2($1)' "$core_limit")
-  local loglog_cpu=$(calc 'log2(max2($1,1))' "$log_cpu")
-  local count=$(calc 'max2($1*$2,1)*3/2' "$log_cpu" "$loglog_cpu")
-  local c1_count=$(calc 'max2($1/3,1)' "$count")
-  local c2_count=$(calc 'max2($1-$2,1)' "$count" "$c1_count")
-  [ $(c2_disabled) = true ] && echo "$c1_count" || echo $(calc '$1+$2' "$c1_count" "$c2_count")
-}
-
-cpu_options() {
-  local core_limit="${JAVA_CORE_LIMIT:-}"
-  if [ "$core_limit" = "0" ]; then
-    return
-  fi
-
-  if [ -n "${CONTAINER_CORE_LIMIT:-}" ]; then
-    if [ -z ${core_limit} ]; then
-      core_limit="${CONTAINER_CORE_LIMIT}"
-    fi
-    echo "-XX:ParallelGCThreads=${core_limit} " \
-         "-XX:ConcGCThreads=${core_limit} " \
-         "-Djava.util.concurrent.ForkJoinPool.common.parallelism=${core_limit} " \
-         "-XX:CICompilerCount=$(ci_compiler_count $core_limit)"
-  fi
-}
-
-#-XX:MinHeapFreeRatio=20  These parameters tell the heap to shrink aggressively and to grow conservatively.
-#-XX:MaxHeapFreeRatio=40  Thereby optimizing the amount of memory available to the operating system.
-heap_ratio() {
-  echo "-XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40"
-}
-
-# These parameters are necessary when running parallel GC if you want to use the Min and Max Heap Free ratios.
-# Skip setting gc_options if any other GC is set in JAVA_OPTIONS.
-# -XX:GCTimeRatio=4
-# -XX:AdaptiveSizePolicyWeight=90
-gc_options() {
-    if echo "${JAVA_OPTIONS:-}" | grep -q -- "-XX:.*Use.*GC"; then
-      return
-    fi
-    local opts="-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 $(heap_ratio)"
-    if [ -z "${JAVA_MAJOR_VERSION:-}" ] || [ "${JAVA_MAJOR_VERSION:-}" != "7" ]; then
-      opts="${opts} -XX:+ExitOnOutOfMemoryError"
-    fi
-    echo $opts
-}
-
-java_default_options() {
-  # Echo options, trimming trailing and multiple spaces
-  echo "$(memory_options) $(jit_options) $(diagnostic_options) $(cpu_options) $(gc_options)" | awk '$1=$1'
-}
-
 # ==============================================================================
 
 # parse the URL
@@ -468,10 +269,17 @@ exec_args() {
 
 # Combine all java options
 java_options() {
+  local script_dir=$(script_dir)
+  local java_default_options=""
+
+  if [ -f "${script_dir}/java-default-options" ]; then
+    java_default_options=$(${script_dir}/java-default-options)
+  fi
+
   # Normalize spaces with awk (i.e. trim and elimate double spaces)
   # See e.g. https://www.physicsforums.com/threads/awk-1-1-1-file-txt.658865/ for an explanation
   # of this awk idiom
-  echo "${JAVA_OPTIONS:-} $(run_java_options) $(debug_options) $(proxy_options) $(java_default_options)" | awk '$1=$1'
+  echo "${JAVA_OPTIONS:-} $(run_java_options) $(debug_options) $(proxy_options) ${java_default_options}" | awk '$1=$1'
 }
 
 # Fetch classpath from env or from a local "run-classpath" file

--- a/test/t/test_helper.bash
+++ b/test/t/test_helper.bash
@@ -71,6 +71,7 @@ get_arg() {
 create_non_exec_run_script() {
   local out=$1
   local extra=$2
+  local tmp_dir=$(dirname ${out})
   local script=$(cat $RUN_JAVA | sed -e 's/^[[:space:]]*exec[[:space:]]/#  exec /g')
 
   cat - <<EOT >$out
@@ -78,6 +79,9 @@ $script
 echo
 $extra
 EOT
+
+  cp ${RUN_JAVA_DIR}/container-limits ${tmp_dir}
+  cp ${RUN_JAVA_DIR}/java-default-options ${tmp_dir}
 }
 
 extract_key_value_from_output() {


### PR DESCRIPTION
https://issues.jboss.org/browse/OSFUSE-728

Need some means for the [S2I images](https://github.com/fabric8io-images/s2i) to get access to the container limit functions during the S2I build. Since the run-java.sh scripts have been collapsed into a single script, this is not currently possible. Hence, I've restored some of the sourceable scripts that were available in previous releases.