### PR TITLE
fix: Allow a zero mem ratio to disable default memory calculations

### DIFF
--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -300,15 +300,17 @@ calc_max_memory() {
 
   # Check for the 'real memory size' and calculate Xmx from the ratio
   if [ -n "${JAVA_MAX_MEM_RATIO:-}" ]; then
-    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_MAX_MEM_RATIO}" "mx"
-  else
-    if [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
-      # Restore the one-fourth default heap size instead of the one-half below 300MB threshold
-      # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html#default_heap_size
-      calc_mem_opt "${CONTAINER_MAX_MEMORY}" "25" "mx"
-    else
-      calc_mem_opt "${CONTAINER_MAX_MEMORY}" "50" "mx"
+    if [ "${JAVA_MAX_MEM_RATIO}" -eq 0 ]; then
+      # Explicitely switched off
+      return
     fi
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_MAX_MEM_RATIO}" "mx"
+  elif [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
+    # Restore the one-fourth default heap size instead of the one-half below 300MB threshold
+    # See https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html#default_heap_size
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "25" "mx"
+  else
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "50" "mx"
   fi
 }
 

--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -322,7 +322,7 @@ calc_init_memory() {
   fi
 
   # Check if value set
-  if [ -z "${JAVA_INIT_MEM_RATIO:-}" ] || [ -z "${CONTAINER_MAX_MEMORY:-}" ]; then
+  if [ -z "${JAVA_INIT_MEM_RATIO:-}" ] || [ -z "${CONTAINER_MAX_MEMORY:-}" ] || [ "${JAVA_INIT_MEM_RATIO}" -eq 0 ]; then
     return
   fi
 

--- a/test/t/03_container_limits.bats
+++ b/test/t/03_container_limits.bats
@@ -24,6 +24,24 @@ load test_helper
   assert_status 0
 }
 
+@test "No mem opts when JAVA_MAX_MEM_RATIO is set to 0" {
+  if [ -n "$MEMORY" ]; then
+    JAVA_MAX_MEM_RATIO="0" run $TEST_SHELL $RUN_JAVA options
+    echo $output
+    assert_not_regexp "-Xmx"
+    assert_status 0
+  fi
+}
+
+@test "Default max mem ratio" {
+  if [ -n "$MEMORY" ]; then
+    run $TEST_SHELL $RUN_JAVA options
+    echo $output
+    assert_regexp "-Xmx"
+    assert_status 0
+  fi
+}
+
 @test "CONTAINER_CORE_LIMIT set" {
   d=$(mktmpdir "maxcpus")
   cp "$TEST_JAR_DIR/test.jar" "$d/test.jar"


### PR DESCRIPTION
This fixes https://issues.jboss.org/browse/OSFUSE-710