### PR TITLE
Fix no_proxy settings with "wildcards"

### DIFF
--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -462,7 +462,7 @@ proxy_options() {
 
   local noProxy="${no_proxy:-${NO_PROXY:-}}"
   if [ -n "$noProxy" ] ; then
-    ret="$ret -Dhttp.nonProxyHosts=\"$(echo $noProxy | sed -e 's/,[[:space:]]*/|/g' | sed -e 's/|\./|\*\./g')\""
+    ret="$ret -Dhttp.nonProxyHosts=\"$(echo "|$noProxy" | sed -e 's/,[[:space:]]*/|/g' | sed -e 's/|\./|\*\./g' | cut -c 2-)\""
   fi
   echo "$ret"
 }

--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -462,7 +462,7 @@ proxy_options() {
 
   local noProxy="${no_proxy:-${NO_PROXY:-}}"
   if [ -n "$noProxy" ] ; then
-    ret="$ret -Dhttp.nonProxyHosts=\"$(echo $noProxy | sed -e 's/,[[:space:]]*/|/g')\""
+    ret="$ret -Dhttp.nonProxyHosts=\"$(echo $noProxy | sed -e 's/,[[:space:]]*/|/g' | sed -e 's/|\./|\*\./g')\""
   fi
   echo "$ret"
 }

--- a/test/t/04_proxy.bats
+++ b/test/t/04_proxy.bats
@@ -75,6 +75,20 @@ load test_helper
   assert_status 0
 }
 
+@test "NO_PROXY setting with wildcard in first element" {
+  d=$(mktmpdir "proxy")
+
+  cp "$TEST_JAR_DIR/test.jar" "$d/test.jar"
+  no_proxy='.example.com, localhost,.cluster.local' JAVA_APP_DIR=$d run $TEST_SHELL $RUN_JAVA
+  echo $status
+  echo $output
+
+  assert_jvmarg "-Dhttp.nonProxyHosts=\"\*.example.com\|localhost\|\*.cluster.local\""
+  assert_command_contains_not "http.proxyHost"
+  assert_command_contains_not "http.proxyHost"
+
+  assert_status 0
+}
 
 @test "All proxy settings" {
   d=$(mktmpdir "proxy")

--- a/test/t/04_proxy.bats
+++ b/test/t/04_proxy.bats
@@ -60,6 +60,22 @@ load test_helper
   assert_status 0
 }
 
+@test "NO_PROXY setting with wildcards" {
+  d=$(mktmpdir "proxy")
+
+  cp "$TEST_JAR_DIR/test.jar" "$d/test.jar"
+  no_proxy='localhost, .example.com' JAVA_APP_DIR=$d run $TEST_SHELL $RUN_JAVA
+  echo $status
+  echo $output
+
+  assert_jvmarg "-Dhttp.nonProxyHosts=\"localhost\|\*.example.com\""
+  assert_command_contains_not "http.proxyHost"
+  assert_command_contains_not "http.proxyHost"
+
+  assert_status 0
+}
+
+
 @test "All proxy settings" {
   d=$(mktmpdir "proxy")
   cp "$TEST_JAR_DIR/test.jar" "$d/test.jar"


### PR DESCRIPTION
 - With `no_proxy=.example.com` in Linux all subdomains will bypass proxy
 - This has to be translated to `-Dhttp.nonProxyHosts=*.example.com`