### PR TITLE
made compatible with dmp-plugin, fixed windows file permission issue (#69)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
   </build>
 
   <dependencies>
+	<dependency>
+	    <groupId>org.apache.commons</groupId>
+	    <artifactId>commons-lang3</artifactId>
+	    <version>3.7</version>
+	</dependency>
+  
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,9 @@
       <resource>
         <directory>fish-pepper</directory>
       </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
     </resources>
 
     <plugins>

--- a/src/main/java/io/fabric8/runsh/RunShLoader.java
+++ b/src/main/java/io/fabric8/runsh/RunShLoader.java
@@ -156,4 +156,16 @@ public class RunShLoader
         }
         return ret;
     }
+
+
+    /**
+     * public interface of dmp plugin. do not remove (see https://dmp.fabric8.io/#docker:build)
+     */
+    public static void addExtraFiles(File directory) {
+    	try {
+			copyRunScript(directory);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+    }
 }

--- a/src/main/java/io/fabric8/runsh/RunShLoader.java
+++ b/src/main/java/io/fabric8/runsh/RunShLoader.java
@@ -12,6 +12,8 @@ import java.util.HashSet;
 import java.util.Scanner;
 import java.util.Set;
 
+import org.apache.commons.lang3.SystemUtils;
+
 
 /**
  * Load and export run-java.sh script
@@ -119,11 +121,15 @@ public class RunShLoader
             targetPath = destination.toPath();
         }
         Files.copy(getInputStream(LOCATION_RUN_SCRIPT), targetPath, StandardCopyOption.REPLACE_EXISTING);
-        Set<PosixFilePermission> perms = new HashSet<>(Files.getPosixFilePermissions(targetPath));
-        perms.add(PosixFilePermission.OWNER_EXECUTE);
-        perms.add(PosixFilePermission.GROUP_EXECUTE);
-        perms.add(PosixFilePermission.OTHERS_EXECUTE);
-        Files.setPosixFilePermissions(targetPath, perms);
+        
+        if (SystemUtils.IS_OS_UNIX) {
+	        Set<PosixFilePermission> perms = new HashSet<>(Files.getPosixFilePermissions(targetPath));
+	        perms.add(PosixFilePermission.OWNER_EXECUTE);
+	        perms.add(PosixFilePermission.GROUP_EXECUTE);
+	        perms.add(PosixFilePermission.OTHERS_EXECUTE);
+	        Files.setPosixFilePermissions(targetPath, perms);
+        }
+        
         return targetPath.toFile();
     }
 

--- a/src/main/resources/META-INF/maven/io.fabric8/dmp-plugin
+++ b/src/main/resources/META-INF/maven/io.fabric8/dmp-plugin
@@ -1,0 +1,1 @@
+io.fabric8.runsh.RunShLoader


### PR DESCRIPTION
The plugin definition and the static method somehow got lost. I've reimplemented those.
The plugin is now also compatible with windows, so you can create docker images on windows as well (see https://dmp.fabric8.io/#docker:build )