### PR TITLE
Introducing variable HIDE_CMD_LINE as option to hide command line from logs

### DIFF
--- a/fish-pepper/run-java-sh/fp-files/run-java.sh
+++ b/fish-pepper/run-java-sh/fp-files/run-java.sh
@@ -620,10 +620,14 @@ run() {
      echo "Either JAVA_MAIN_CLASS or JAVA_APP_JAR needs to be given"
      exit 1
   fi
+
+  if [ "${HIDE_CMD_LINE:-}" != 1 ] && [ "${HIDE_CMD_LINE:-}" != true ]; then
+    echo exec $(exec_args) java $(java_options) -cp "$(classpath)" ${args} "$@"
+  fi
+
   # Don't put ${args} in quotes, otherwise it would be interpreted as a single arg.
   # However it could be two args (see above). zsh doesn't like this btw, but zsh is not
   # supported anyway.
-  echo exec $(exec_args) java $(java_options) -cp "$(classpath)" ${args} "$@"
   exec $(exec_args) java $(java_options) -cp "$(classpath)" ${args} "$@"
 }
 

--- a/fish-pepper/run-java-sh/readme.md
+++ b/fish-pepper/run-java-sh/readme.md
@@ -35,6 +35,7 @@ The startup process is configured mostly via environment variables:
 * **HTTP_PROXY** The URL of the proxy server that translates into the `http.proxyHost` and `http.proxyPort` system properties.
 * **HTTPS_PROXY** The URL of the proxy server that translates into the `https.proxyHost` and `https.proxyPort` system properties.
 * **no_proxy**, **NO_PROXY** The list of hosts that should be reached directly, bypassing the proxy, that translates into the `http.nonProxyHosts` system property.
+* **HIDE_CMD_LINE** By default, the startup script logs the full command line used to startup the java application. Setting this variable to `1` or `true` disables this behavior.
 
 If neither `$JAVA_APP_JAR` nor `$JAVA_MAIN_CLASS` is given, `$JAVA_APP_DIR` is checked for a single JAR file which is taken as `$JAVA_APP_JAR`. If no or more then one jar file is found, an error is thrown.
 


### PR DESCRIPTION
In some cases, the application handled by run-java.sh requires password to be informed in the command line. Considering that currently the script outputs the command line at startup, this may present security risks. This PR introduces a variable that disables this behavior if user desires. Default behavior is unaltered.